### PR TITLE
Fix for missing center-code attribute

### DIFF
--- a/pyhml/pyhml.py
+++ b/pyhml/pyhml.py
@@ -237,6 +237,8 @@ class HmlParser(object):
                 xmldata.update({k: ''})
 
         for i in range(0, len(xmldata['hmlns:sample'])):
+            if '@center-code' not in xmldata['hmlns:sample'][i]:
+                xmldata['hmlns:sample'][i].update({'@center-code': ''})
             for j in range(0, len(xmldata['hmlns:sample'][i]['hmlns:typing'])):
                 for k in range(0, len(xmldata['hmlns:sample'][i]['hmlns:typing'][j]['hmlns:allele-assignment'])):
                     if 'hmlns:glstring' not in xmldata['hmlns:sample'][i]['hmlns:typing'][j]['hmlns:allele-assignment'][k]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.0.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ test_requirements = [
 
 setup(
     name='pyhml',
-    version='0.0.5',
+    version='0.0.6',
     description="Python HML parser",
     long_description=readme + '\n\n' + history,
     author="Mike Halagan",


### PR DESCRIPTION
center-code is an optional attribute on sample nodes in HML 1.0.1, but pyHML crashes if it's missing. This fills the attribute with a blank string.